### PR TITLE
Configure IAM roles for job cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,17 @@ Various options can be passed to control the running of the job. In particular t
   - `--num-ec2-instances` number of instances (including the master). Default is `2`.
   - `--ami-version` the ami version. Default is `latest`.
   - `--hive-version`. Default is `latest`.
+  - `--iam-instance-profile` role for the EC2 instances on the cluster. Default is `EMR_EC2_DefaultRole`.
+  - `--iam-service-role` role for the Amazon EMR service on the cluster. Default is `EMR_DefaultRole`.
   - `--s3-sync-wait-time` to configure how long to wait after uploading files to S3.
   - `--check-emr-status-every` configure the interval between each status check on a running job.
   - `--quiet` less logging
   - `--verbose` more logging
   - `--retain-hive-table` for local mode, keep the hive table to run further ad-hoc queries.
+
+*NOTE: IAM roles will be mandatory for all users after June 30, 2015. These are set via the `--iam-instance-profile` and `--iam-service-role` options above.*
+
+*See [Configure IAM Roles for Amazon EMR](http://docs.aws.amazon.com/ElasticMapReduce/latest/DeveloperGuide/emr-iam-roles.html)*
 
 ### Configuration file
 

--- a/apiarist/conf.py
+++ b/apiarist/conf.py
@@ -60,6 +60,9 @@ class YamlConfig():
         'hive_version': '--hive-version',
         'ami_version': '--ami-version',
 
+        'iam_instance_profile': '--iam-instance-profile',  # default: EMR_EC2_DefaultRole
+        'iam_service_role': '--iam-service-role',  # default: EMR_DefaultRole
+
         'ec2_master_instance_type': '--ec2-master-instance-type',
         'ec2_instance_type': '--ec2-instance-type',
         'num_ec2_instances': '--num-ec2-instances',

--- a/apiarist/emr.py
+++ b/apiarist/emr.py
@@ -37,6 +37,7 @@ class EMRRunner():
                  output_dir=None, scratch_uri=None, log_path=None,
                  ami_version=None, hive_version=None, num_instances=None,
                  master_instance_type=None, slave_instance_type=None,
+                 iam_instance_profile=None, iam_service_role=None,
                  aws_access_key_id=None, aws_secret_access_key=None,
                  s3_sync_wait_time=5, check_emr_status_every=30,
                  temp_dir=None):
@@ -83,6 +84,8 @@ class EMRRunner():
         self.ami_version = ami_version
         self.hive_version = hive_version
         self.num_instances = num_instances
+        self.iam_instance_profile = iam_instance_profile
+        self.iam_service_role = iam_service_role
 
         # S3 'scratch' directory
         if scratch_uri:
@@ -165,7 +168,9 @@ class EMRRunner():
             master_instance_type=self.master_instance_type,
             slave_instance_type=self.slave_instance_type,
             ami_version=self.ami_version,
-            num_instances=self.num_instances)
+            num_instances=self.num_instances,
+            job_flow_role=self.iam_instance_profile,
+            service_role=self.iam_service_role)
 
         conn.add_jobflow_steps(jobid, [setup_step, run_step])
 

--- a/apiarist/launch.py
+++ b/apiarist/launch.py
@@ -144,6 +144,8 @@ class HiveJobLauncher(object):
             'num_instances': self.options.num_instances,
             'ami_version': self.options.ami_version,
             'hive_version': self.options.hive_version,
+            'iam_instance_profile': self.options.iam_instance_profile,
+            'iam_service_role': self.options.iam_service_role,
             's3_sync_wait_time': self.options.s3_sync_wait_time,
             'check_emr_status_every': self.options.check_emr_status_every,
             'temp_dir': self.options.scratch_dir
@@ -197,7 +199,7 @@ class HiveJobLauncher(object):
             action='store', default=False
             )
 
-        # hadoop config, job concurrency, and instance sizes
+        # hadoop config, job concurrency, instance sizes and IAM roles
         self.option_parser.add_option(
             '--ec2-master-instance-type', dest='master_instance_type',
             action='store', default=False
@@ -217,6 +219,14 @@ class HiveJobLauncher(object):
         self.option_parser.add_option(
             '--hive-version', dest='hive_version',
             action='store', default='latest'
+            )
+        self.option_parser.add_option(
+            '--iam-instance-profile', dest='iam_instance_profile',
+            action='store', default='EMR_EC2_DefaultRole'
+            )
+        self.option_parser.add_option(
+            '--iam-service-role', dest='iam_service_role',
+            action='store', default='EMR_DefaultRole'
             )
 
         # job runner options

--- a/tests/conf_test.py
+++ b/tests/conf_test.py
@@ -53,6 +53,14 @@ class ConfigFileTest(unittest.TestCase):
         self.assert_contains_args(self.args,
                                   ['--ami-version', '1.0.0'])
 
+    def iam_instance_profile_test(self):
+        self.assert_contains_args(self.args,
+                                  ['--iam-instance-profile', 'EMR_EC2_OtherRole'])
+
+    def iam_service_role_test(self):
+        self.assert_contains_args(self.args,
+                                  ['--iam-service-role', 'EMR_OtherRole'])
+
     def s3_log_uri_test(self):
         self.assert_contains_args(self.args,
                                   ['--s3-log-uri', 's3://foo/bar/'])

--- a/tests/launch_test.py
+++ b/tests/launch_test.py
@@ -63,6 +63,22 @@ class HiveJobLauncherTest(unittest.TestCase):
         j = HiveJobLauncher('TestJob', [self.DATA_PATH, '--hive-version', v])
         self.assertEqual(v, j.options.hive_version)
 
+    def supply_iam_instance_profile_test(self):
+        # defaults to 'EMR_EC2_DefaultRole'
+        j = HiveJobLauncher('TestJob', [self.DATA_PATH])
+        self.assertEqual('EMR_EC2_DefaultRole', j.options.iam_instance_profile)
+        iip = 'EMR_EC2_OtherRole'
+        j = HiveJobLauncher('TestJob', [self.DATA_PATH, '--iam-instance-profile', iip])
+        self.assertEqual(iip, j.options.iam_instance_profile)
+
+    def supply_iam_service_role_test(self):
+        # defaults to 'EMR_DefaultRole'
+        j = HiveJobLauncher('TestJob', [self.DATA_PATH])
+        self.assertEqual('EMR_DefaultRole', j.options.iam_service_role)
+        isr = 'EMR_OtherRole'
+        j = HiveJobLauncher('TestJob', [self.DATA_PATH, '--iam-service-role', isr])
+        self.assertEqual(isr, j.options.iam_service_role)
+
     def this_class_has_no_query_test(self):
         j = HiveJobLauncher('TestJob', ['s3://path/to/data/'])
         self.assertRaises(NotImplementedError, j.hive_query)

--- a/tests/test-config.conf
+++ b/tests/test-config.conf
@@ -7,6 +7,8 @@ runners:
     aws_secret_access_key: bar
     hive_version: 2.0.0
     ami_version: 1.0.0
+    iam_instance_profile: EMR_EC2_OtherRole
+    iam_service_role: EMR_OtherRole
     s3_log_uri: s3://foo/bar/
     s3_scratch_uri: s3://foo/baz/
     s3_sync_wait_time: 7


### PR DESCRIPTION
Configure (2) IAM roles for job cluster:
 - a role for the EC2 instances (instance profile)
 - a role for the Amazon EMR service (service role)
