### PR TITLE
refactored to stop using deprecated 'DescribeJobFlows' API via Boto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,13 @@
-PyYAML==3.11
-boto==2.32.1
+boto==2.38.0
+docutils==0.12
 flake8==2.2.2
+futures==2.2.0
+jmespath==0.9.0
 mccabe==0.2.1
 nose==1.3.3
 pep8==1.5.7
 pyflakes==0.8.1
 pypandoc==0.8.4
-wsgiref==0.1.2
+python-dateutil==2.4.2
+PyYAML==3.11
+six==1.10.0

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ try:
     # arguments that distutils doesn't understand
     setuptools_kwargs = {
         'install_requires': [
-            'boto>=2.2.0'
+            'boto>=2.6.0'
         ],
         'provides': ['apiarist']
     }
@@ -45,7 +45,6 @@ setup(
         'Natural Language :: English',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.5',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Topic :: System :: Distributed Computing',

--- a/tests/emr_test.py
+++ b/tests/emr_test.py
@@ -10,6 +10,9 @@ class EmrTest(unittest.TestCase):
     # not many tests here
     # need to find a way to mock AWS
 
+    def setUp(self):
+        os.environ['S3_SCRATCH_URI'] = 's3://foo/bar/'
+
     def has_a_job_name_test(self):
         r = EMRRunner('TestJob')
         self.assertEqual(r.job_name, 'TestJob')
@@ -19,7 +22,8 @@ class EmrTest(unittest.TestCase):
         del os.environ['AWS_SECRET_ACCESS_KEY']
         k, s = 'foo', 'bar'
         r = EMRRunner('TestJob',
-                      aws_access_key_id=k, aws_secret_access_key=s)
+                      aws_access_key_id=k,
+                      aws_secret_access_key=s)
         self.assertEqual(r.aws_access_key_id, k)
         self.assertEqual(r.aws_secret_access_key, s)
         self.assertEqual(os.environ['AWS_ACCESS_KEY_ID'], k)


### PR DESCRIPTION
AWS will kill the 'DescribeJobFlows' API on December 14.

This change uses the new "cluster" terminology in stead of "job flow" and accesses, via Boto, the new APIs for information about the running jobs. 