### PR TITLE
Add visibility options for EMR Cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ Various options can be passed to control the running of the job. In particular t
   - `--quiet` less logging
   - `--verbose` more logging
   - `--retain-hive-table` for local mode, keep the hive table to run further ad-hoc queries.
+  - `--visible-to-all-users` make your cluster visible to all IAM users on the same AWS account. Set by default
+  - `--no-visible-to-all-users` hide your cluster from other IAM users on the same AWS account
+
 
 *NOTE: IAM roles will be mandatory for all users after June 30, 2015. These are set via the `--iam-instance-profile` and `--iam-service-role` options above.*
 
@@ -153,7 +156,7 @@ Some environment variables are used when the value is not provided in other conf
 
 `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` for connecting to AWS.
 
-`S3_SCRATCH_URI` a S3 base location where all the temporary file for the job will be written. 
+`S3_SCRATCH_URI` a S3 base location where all the temporary file for the job will be written.
 
 `APIARIST_TMP_DIR` where local files will be written during job runs. (This is overridden by the `--local-scratch-dir` option)
 
@@ -161,7 +164,7 @@ Some environment variables are used when the value is not provided in other conf
 
 ### Passing options to your jobs
 
-Jobs can be configured to accept arguments. 
+Jobs can be configured to accept arguments.
 
 To do this, add the following method to your job class to configutr the options:
 

--- a/apiarist/emr.py
+++ b/apiarist/emr.py
@@ -41,6 +41,7 @@ class EMRRunner():
                  master_instance_type=None, slave_instance_type=None,
                  iam_instance_profile=None, iam_service_role=None,
                  aws_access_key_id=None, aws_secret_access_key=None,
+                 visible_to_all_users=None,
                  s3_sync_wait_time=5, check_emr_status_every=30,
                  label=None, owner=None, temp_dir=None):
 
@@ -63,6 +64,12 @@ class EMRRunner():
         else:
             logger.debug("Getting AWS secret key from ENV")
             self.aws_secret_access_key = os.environ['AWS_SECRET_ACCESS_KEY']
+
+        # Set visibility of job flow to all users if visible_to_all_users is None
+        if visible_to_all_users is None:
+            self.visible_to_all_users = True
+        else:
+            self.visible_to_all_users = visible_to_all_users
 
         self.s3_sync_wait_time = s3_sync_wait_time
         self.check_emr_status_every = check_emr_status_every
@@ -197,7 +204,8 @@ class EMRRunner():
             ami_version=self.ami_version,
             num_instances=self.num_instances,
             job_flow_role=self.iam_instance_profile,
-            service_role=self.iam_service_role)
+            service_role=self.iam_service_role,
+            visible_to_all_users=self.visible_to_all_users)
 
         conn.add_jobflow_steps(cluster_id, [setup_step, run_step])
 

--- a/apiarist/launch.py
+++ b/apiarist/launch.py
@@ -148,6 +148,7 @@ class HiveJobLauncher(object):
             'hive_version': self.options.hive_version,
             'iam_instance_profile': self.options.iam_instance_profile,
             'iam_service_role': self.options.iam_service_role,
+            'visible_to_all_users': self.options.visible_to_all_users,
             's3_sync_wait_time': self.options.s3_sync_wait_time,
             'check_emr_status_every': self.options.check_emr_status_every,
             'temp_dir': self.options.scratch_dir
@@ -239,6 +240,14 @@ class HiveJobLauncher(object):
         self.option_parser.add_option(
             '--iam-service-role', dest='iam_service_role',
             action='store', default='EMR_DefaultRole'
+            )
+        self.option_parser.add_option(
+            '--visible-to-all-users', dest='visible_to_all_users',
+            action='store_true'
+            )
+        self.option_parser.add_option(
+            '--no-visible-to-all-users', dest='visible_to_all_users',
+            action='store_false'
             )
 
         # job runner options


### PR DESCRIPTION
Add `--visible-to-all-users` and `--no-visible-to-all-users` options.
Options resolve to a single value which defaults to True when not set.
Mimics mrjob options.